### PR TITLE
make it possible for ssh-agent forwarding to work with docker-compose

### DIFF
--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 IMAGE_NAME=uber/ssh-agent-forward:latest
 CONTAINER_NAME=pinata-sshd
-VOLUME_NAME=ssh-agent
+LOCAL_VOLUME_DIR_NAME=/tmp/ssh-agent
 HOST_PORT=2244
 AUTHORIZED_KEYS=$(ssh-add -L | base64 | tr -d '\n')
 KNOWN_HOSTS_FILE=$(mktemp -t dsaf.XXX)
@@ -12,12 +12,10 @@ trap 'rm ${KNOWN_HOSTS_FILE}' EXIT
 
 docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 
-docker volume create --name "${VOLUME_NAME}"
-
 docker run \
   --name "${CONTAINER_NAME}" \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
-  -v ${VOLUME_NAME}:/ssh-agent \
+  -v ${LOCAL_VOLUME_DIRNAME}:/ssh-agent \
   -d \
   -p "${HOST_PORT}:22" \
   "${IMAGE_NAME}" >/dev/null \


### PR DESCRIPTION
## Summary

* make it possible for ssh-agent forwarding to work with `docker-compose`.
* docker-compose can't mount docker volumes not created inside docker-compose, so use a temporary directory on the host to hold the ssh-agent socket.